### PR TITLE
Fixed playertimes randomly reverting to negatives.

### DIFF
--- a/lua/ev_plugins/sv_playerinfo.lua
+++ b/lua/ev_plugins/sv_playerinfo.lua
@@ -73,20 +73,34 @@ end
 
 function PLUGIN:PlayerDisconnected( ply )
 	ply:SetProperty( "LastJoin", os.time() )
-	ply:SetProperty( "PlayTime", ply:GetProperty( "PlayTime" ) + os.clock() - ply.EV_LastPlaytimeSave )
+	ply:SetProperty( "PlayTime", ply:GetProperty( "PlayTime" ) + math.abs(os.difftime(os.clock(),ply.EV_LastPlaytimeSave)) )
 	
 	evolve:CommitProperties()
 end
 
+-- Code patched for 64 bit systems, where clock.time() is returning too high of a precision double which over flows 32 bit values into negatives.
 timer.Create( "EV_PlayTimeSave", 60, 0, function()
 	for _, ply in ipairs( player.GetAll() ) do
-		ply:SetProperty( "LastJoin", os.time() )
-		ply:SetProperty( "PlayTime", ply:GetProperty( "PlayTime" ) + os.clock() - ply.EV_LastPlaytimeSave )
-		
-		ply.EV_LastPlaytimeSave = os.clock()
-	end
-	
-	evolve:CommitProperties()
+        -- Check for bad PlayTime values and set them back to 0, usually only for catching new players spawning with negative values.
+        if(ply:GetProperty( "PlayTime" ) < 0) then
+          ply:SetProperty( "PlayTime", 0)
+        end
+        
+        ply:SetProperty( "LastJoin", os.time() )
+        clock = os.clock()
+        last = ply.EV_LastPlaytimeSave
+        
+        -- When the clock flips negative/positive, we don't want large differences between the old clock value stored in last.
+        if((clock < 0 && last > 0) || (clock > 0 && last < 0)) then 
+          last = os.clock()
+        end
+        
+        -- Set the PlayTime value to the absoulte difference in clock times.
+        ply:SetProperty( "PlayTime", ply:GetProperty( "PlayTime" ) + math.abs(os.difftime(clock,last)) )
+        ply.EV_LastPlaytimeSave = os.clock()
+    end
+    
+    evolve:CommitProperties()
 end )
 
 evolve:RegisterPlugin( PLUGIN )


### PR DESCRIPTION
The issue was due to the fact that srcds is 32-bit and os.clock() returns a 64-bit value on 64-bit systems. Around os.clock() time of 2140.xx, the decimal precsion increases and the negative bit gets set. So the values start counting at -2140.xxxxxx back toward 0. In order to solve this problem, we take the absolute differences in time values of the clock rather than just subtracting new - old.
