### PR TITLE
Fixed not usable console-commands like "ev map"

### DIFF
--- a/lua/ev_plugins/sv_consolecommands.lua
+++ b/lua/ev_plugins/sv_consolecommands.lua
@@ -28,7 +28,7 @@ function PLUGIN:CCommand( ply, com, cargs )
 	for _, plugin in ipairs( evolve.plugins ) do
 		if ( plugin.ChatCommand == command or ( type( plugin.ChatCommand ) == "table" and table.HasValue( plugin.ChatCommand, command ) ) ) then
 			evolve.SilentNotify = string.Left( com, 1 ) == "@"			
-				res, ret = pcall( plugin.Call, plugin, ply, args, string.sub( com, #command + 3 ), command )
+			res, ret = pcall( plugin.Call, plugin, ply, args, string.sub( com, #command + 3 ), command )
 			evolve.SilentNotify = false
 			
 			if ( !res ) then


### PR DESCRIPTION
The function checked only if plugin.ChatCommand was a string - changed it now to same behavior than sv_chatcommands to also check if the plugin.ChatCommand is using a table.

So this fixes for example the use of map change plugin from console.
Fixes #42 too.
