### PR TITLE
Added the modification to Player:GetUserGroup()

### DIFF
--- a/lua/ev_framework.lua
+++ b/lua/ev_framework.lua
@@ -592,6 +592,11 @@ function _R.Player:IsUserGroup( group )
 	return self:GetNWString( "UserGroup" ) == group or self:EV_GetRank() == group
 end
 
+function _R.Player:GetUserGroup()
+	if ( !self:IsValid() ) then return "" end
+	return self:EV_GetRank()
+end
+
 function evolve:RankGroup( ply, rank )
 	ply:SetUserGroup( evolve.ranks[ rank ].UserGroup )
 end


### PR DESCRIPTION
The method [Player:GetUserGroup()](http://wiki.garrysmod.com/page/Player/GetUserGroup) was not modified to work properly with Evolve.
Here is the modification.