### PR TITLE
Update to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lua/includes/ev_vON"]
 	path = lua/includes/ev_von
-	url = git@github.com:vercas/vON.git
+	url = https://github.com/vercas/vON.git

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ How do I install evolve?
 
 To install evolve, you can either download it as a zip or use git.
 
-If you use git, simply clone it using `git clone --recursive git@github.com:Xandaros/evolve.git` and you're good to go.  
+If you use git, simply clone it using `git clone --recursive https://github.com/Xandaros/evolve.git` and you're good to go.  
 If you later want to update it, you can use `git pull` to update evolve and `git submodule update` to update the submodules, which are required to run evolve.
 
 To install evolve with a zip file, first download the [evolve zip file](https://github.com/Xandaros/evolve/archive/master.zip) and unzip it into your addons folder. Make sure the folder in your addons directory contains a file called "README.md".  


### PR DESCRIPTION
Cloning a repository over SSH requires setting up a keypair in your GitHub account. This can cause issues with people who:
1. aren't entirely sure about proper SSH authentication methods, or
2. don't have a GitHub account.

Therefore it is recommended to use HTTPS remote URLs instead.