### PR TITLE
Fixed a shallow copy to the rank color variable

### DIFF
--- a/lua/ev_plugins/sh_playernames.lua
+++ b/lua/ev_plugins/sh_playernames.lua
@@ -92,7 +92,7 @@ else
 						surface.DrawTexturedRect( drawPos.x + 5, drawPos.y + 5, 14, 14 )
 						
 						local col = evolve.ranks[ pl:EV_GetRank() ].Color or team.GetColor( pl:Team() )
-						col.a = math.Clamp( alpha * 2, 0, 255 )
+						col = Color(col.r, col.g, col.b, math.Clamp( alpha * 2, 0, 255 ))
 						draw.DrawText( pl:Nick(), "DefaultBold", drawPos.x + 28, drawPos.y + 5, col, 0 )
 					end
 				end


### PR DESCRIPTION
The way the alpha value was set for the overhead nameplates plugin was inadvertently creating a shallow copy, causing the actual rank color variable to be modified. This was causing an issue when attempting to integrate Evolve's rank colors into other addons, as that alpha variable would carry over into the other addon as players faded from view.