### PR TITLE
Fix for perma-bans being accidentally purged from ban-list.

### DIFF
--- a/lua/ev_framework.lua
+++ b/lua/ev_framework.lua
@@ -486,7 +486,7 @@ function evolve:CommitProperties()
 		table.SortByMember( info, "LastJoin", function(a, b) return a > b end )
 		
 		for _, entry in pairs( info ) do
-			if ( ( !entry.BanEnd or entry.BanEnd < os.time() ) and ( !entry.Rank or entry.Rank == "guest" ) ) then
+			if ( ( !entry.BanEnd or (entry.BanEnd != 0 and entry.BanEnd < os.time()) ) and ( !entry.Rank or entry.Rank == "guest" ) ) then
 				evolve.PlayerInfo[ entry.UID ] = nil
 				count = count - 1
 				if ( count < 800 ) then break end

--- a/lua/ev_framework.lua
+++ b/lua/ev_framework.lua
@@ -481,7 +481,7 @@ function evolve:CommitProperties()
 		local original = count
 		local info = {}
 		for uid, entry in pairs( evolve.PlayerInfo ) do
-			table.insert( info, { UID = uid, LastJoin = entry.LastJoin, Rank = entry.Rank } )
+			table.insert( info, { UID = uid, LastJoin = entry.LastJoin, Rank = entry.Rank, BanEnd = entry.BanEnd } )
 		end
 		table.SortByMember( info, "LastJoin", function(a, b) return a > b end )
 		


### PR DESCRIPTION
I've noticed that over time, perma-bans are purged from the player info database, and I think it is because during this check for non-expired bans, it checks if the BanEnd time is less than the current OS time. However, since perma-bans are saved with a time of 0, they are always less than the current OS time. Therefore, I have included a check for perma-bans that should not allow them to be purged.

Evaluating my data for a few weeks to verify that this fix is effective, then will release the draft.

I also question the performance gains that this purge even provides, however I'm afraid to completely disable it to find out.