### PR TITLE
Fixed Cleanup Command Not Cleaning Up All Entities

### DIFF
--- a/lua/ev_plugins/sh_cleanup.lua
+++ b/lua/ev_plugins/sh_cleanup.lua
@@ -9,13 +9,12 @@ PLUGIN.Author = "Overv, MadDog896, Divran"
 PLUGIN.ChatCommand = "cleanup"
 PLUGIN.Usage = "[player]"
 PLUGIN.Privileges = { "Cleanup" }
-PLUGIN.ignore_classes = {}
 
 function PLUGIN:Call( ply, args )
 	if ( ply:EV_HasPrivilege( "Cleanup" ) ) then
 		if ( #args == 0 ) then
 			evolve:Notify( evolve.colors.blue, ply:Nick(), evolve.colors.white, " has cleaned up the map." )
-			game.CleanUpMap( false, self.ignore_classes )
+			game.CleanUpMap()
 		else
 			local players = evolve:FindPlayer( args )
 			
@@ -35,18 +34,5 @@ function PLUGIN:Call( ply, args )
 		evolve:Notify( ply, evolve.colors.red, evolve.constants.notallowed )
 	end
 end
-
-function PLUGIN:InitPostEntity()
-	local lookup = {}
-	local entities = ents.GetAll()
-	for i=1,#entities do
-		local class = entities[i]:GetClass()
-		if not lookup[class] then
-			lookup[class] = true
-			self.ignore_classes[#self.ignore_classes+1] = class
-		end
-	end
-end
-
 
 evolve:RegisterPlugin( PLUGIN )


### PR DESCRIPTION
Fixes #176 

Removed logic that added entity classes present on server start to filter list for !cleanup command. I do not believe this to be needed from what I have seen.