### PR TITLE
Fixed "Cbuf_AddText: buffer overflow" error relating to Ban list refresh on server start

### DIFF
--- a/lua/ev_plugins/sh_ban.lua
+++ b/lua/ev_plugins/sh_ban.lua
@@ -72,7 +72,8 @@ function PLUGIN:Call( ply, args )
 end
 
 if ( SERVER ) then
-	function PLUGIN:InitPostEntity()
+	function PLUGIN:Initialize()
+		evolve:Message( "== Executing Ban List ==" )
 		for uid, data in pairs( evolve.PlayerInfo ) do
 			if ( evolve:IsBanned( uid ) ) then
 				game.ConsoleCommand( "banid " .. ( data.BanEnd - os.time() ) / 60 .. " " .. data.SteamID .. "\n" )


### PR DESCRIPTION
This fix resolves Issue #99, at least when caused by the situation described below.

This stemmed from my server beginning to not load certain config file line entries after running for many years, throwing a "Cbuf_AddText: buffer overflow" error for random entries in the config. The issue appeared to get progressively worse over the course of the last month, to where it eventually would not load most of the config at all after a cold start.

After some troubleshooting, I narrowed the issue down to Evolve, specifically the Ban refresh loop that occurs at the start of every server run.

Essentially, from what I can tell, when the Ban list refresh function was happening during the InitPostEntity hook, the server was also executing the main config file load at that exact instant. I believe this loop, where hundreds of players are banned in the same instant as the config file load, somehow overloaded that backend Cbuf_AddText function the config system uses.

To resolve this, I have simply moved the ban list refresh to occur in the Initialize hook, rather than in InitPostEntity. Initialize occurs a few moments before InitPostEntity, and while the server will not print the bans to the log (because sv_logbans would have not been set yet, as the config isn't loaded at that point), I believe it is executing the loop properly within that hook, as it is still throwing the normal error for the bot accounts I had banned for fun, implying that the ban loop is running. I also tested by banning myself, and the ban properly persisted after restart.

Another fix I had initially considered was simply delaying that ban refresh by a couple of seconds, however it appears the server's timer is not started when Initialize() occurs, and so I could think of an efficient way to simply execute something a specific time after server initialization.
